### PR TITLE
Get linting and tests working

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+.venv

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ build:
 run:
 	docker compose up
 
+lint:
+	docker compose run --rm app shell ruff format --check
+	docker compose run --rm app shell ruff check
+
+test:
+	docker compose run --rm web shell /app/script/test.sh
+
 start-container:
 	docker run -d -p 8000:8000 --rm $(current_dir):latest
 

--- a/README.md
+++ b/README.md
@@ -44,4 +44,10 @@ Environment variables you can set:
 
   <dt>`OTEL_COLLECTOR_ENDPOINT`</dt>
   <dd>Host and port for the OpenTelemetry collector to use.</dd>
+
+  <dt>`RUNNING_UNITTESTS`</dt>
+  <dd>
+    `1` if running unittests. This causes OpenTelemetry to be
+    configured using no-op exporters and providers.
+  </dd>
 </dl>

--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ To run tests:
 ```
 make test
 ```
+
+## Configuration
+
+Environment variables you can set:
+
+<dl>
+  <dt>`ENVIRONMENT`</dt>
+  <dd>The environment this is running in.</dd>
+
+  <dt>`OTEL_COLLECTOR_ENDPOINT`</dt>
+  <dd>Host and port for the OpenTelemetry collector to use.</dd>
+</dl>

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,21 @@
 from fastapi import FastAPI
 from dockerflow.fastapi import router as dockerflow_router
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from app.observability import setup_otel_exporter, setup_structured_logging
+from app.observability import (
+    instrument_app,
+    setup_otel_exporter,
+    setup_structured_logging,
+)
 from app.routes import router
 from app.settings import settings
 
+
 setup_structured_logging()
 setup_otel_exporter("mzcld-demo", settings.otel_collector_endpoint)
+
 
 # fast api app setup
 app = FastAPI()
 app.include_router(dockerflow_router)
 app.include_router(router)
-FastAPIInstrumentor.instrument_app(app)
+instrument_app(app)

--- a/app/observability.py
+++ b/app/observability.py
@@ -46,6 +46,11 @@ def get_exporter(
 
 
 def setup_otel_exporter(app_name: str, endpoint: str):
+    if settings.running_unittests == 1:
+        # If we're running unittests, skip setting up exporter and provider so
+        # it's using the default no-op things
+        return
+
     logger.info(
         "Starting opentelemetry exporter %s", endpoint, extra={"endpoint": endpoint}
     )

--- a/app/observability.py
+++ b/app/observability.py
@@ -2,8 +2,12 @@ import logging
 from logging.config import dictConfig
 import sys
 from typing import Tuple
+
+# Instrumentation
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
+# Trace things
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
@@ -13,6 +17,7 @@ from opentelemetry.sdk.trace.export import (
     SpanExporter,
 )
 
+# Metrics things
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
@@ -22,11 +27,12 @@ from opentelemetry.sdk.metrics.export import (
     PeriodicExportingMetricReader,
 )
 
-
+# Logging things
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from pythonjsonlogger.json import JsonFormatter
 
 from app.settings import settings
+
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +45,10 @@ def get_exporter(
     return (OTLPSpanExporter(endpoint, True), OTLPMetricExporter(endpoint, True))
 
 
-def setup_otel_exporter(app_name: str, endpoint: str = "localhost:4317"):
-    logger.info("Starting opentelemetry exporter", extra={"endpoint": endpoint})
+def setup_otel_exporter(app_name: str, endpoint: str):
+    logger.info(
+        "Starting opentelemetry exporter %s", endpoint, extra={"endpoint": endpoint}
+    )
 
     # Service name is required for most backends
     resource = Resource.create(attributes={SERVICE_NAME: app_name})
@@ -115,3 +123,7 @@ def setup_structured_logging() -> None:
             },
         }
     )
+
+
+def instrument_app(app):
+    FastAPIInstrumentor.instrument_app(app)

--- a/app/routes.py
+++ b/app/routes.py
@@ -17,7 +17,7 @@ router = APIRouter()
 @router.get("/")
 async def read_root():
     logger.info("Hello World")
-    return {"Hello": "World"}
+    return {"msg": "Hello World"}
 
 
 @router.get("/items/{item_id}")

--- a/app/settings.py
+++ b/app/settings.py
@@ -4,6 +4,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     otel_collector_endpoint: str = "localhost:4317"
     environment: str = "development"
+    running_unittests: int = 0
 
 
 settings = Settings()

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,9 @@ services:
     ports:
       - 8000:8000
     environment:
-      OTEL_COLLECTOR_HOST: otel-collector:4317
+      OTEL_COLLECTOR_ENDPOINT: otel-collector:4317
+    depends_on:
+      - otel-collector
     develop:
       watch:
         - path: ./app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.53b1",
     "opentelemetry-instrumentation-logging>=0.53b1",
     "pydantic-settings>=2.9.1",
+    "pytest>=8.3.5",
     "python-json-logger>=3.3.0",
     "rich>=14.0.0",
+    "ruff>=0.11.7",
 ]

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pytest $@

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+export RUNNING_UNITTESTS=1
+
 pytest $@

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_read_main():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Hello World"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -309,6 +310,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -392,8 +402,10 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "pydantic-settings" },
+    { name = "pytest" },
     { name = "python-json-logger" },
     { name = "rich" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -406,8 +418,10 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.53b1" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.53b1" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "rich", specifier = ">=14.0.0" },
+    { name = "ruff", specifier = ">=0.11.7" },
 ]
 
 [[package]]
@@ -616,6 +630,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
 name = "protobuf"
 version = "5.29.4"
 source = { registry = "https://pypi.org/simple" }
@@ -707,6 +730,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]
@@ -802,6 +840,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/ea/13945d58d556a28dfb0f774ad5c8af759527390e59505a40d164bf8ce1ce/rich_toolkit-0.14.1.tar.gz", hash = "sha256:9248e2d087bfc01f3e4c5c8987e05f7fa744d00dd22fa2be3aa6e50255790b3f", size = 104416 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/e8/61c5b12d1567fdba41a6775db12a090d88b8305424ee7c47259c70d33cb4/rich_toolkit-0.14.1-py3-none-any.whl", hash = "sha256:dc92c0117d752446d04fdc828dbca5873bcded213a091a5d3742a2beec2e6559", size = 24177 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/89/6f9c9674818ac2e9cc2f2b35b704b7768656e6b7c139064fc7ba8fbc99f1/ruff-0.11.7.tar.gz", hash = "sha256:655089ad3224070736dc32844fde783454f8558e71f501cb207485fe4eee23d4", size = 4054861 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/ec/21927cb906c5614b786d1621dba405e3d44f6e473872e6df5d1a6bca0455/ruff-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:d29e909d9a8d02f928d72ab7837b5cbc450a5bdf578ab9ebee3263d0a525091c", size = 10245403 },
+    { url = "https://files.pythonhosted.org/packages/e2/af/fec85b6c2c725bcb062a354dd7cbc1eed53c33ff3aa665165871c9c16ddf/ruff-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dd1fb86b168ae349fb01dd497d83537b2c5541fe0626e70c786427dd8363aaee", size = 11007166 },
+    { url = "https://files.pythonhosted.org/packages/31/9a/2d0d260a58e81f388800343a45898fd8df73c608b8261c370058b675319a/ruff-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d3d7d2e140a6fbbc09033bce65bd7ea29d6a0adeb90b8430262fbacd58c38ada", size = 10378076 },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/9b09b45051404d2e7dd6d9dbcbabaa5ab0093f9febcae664876a77b9ad53/ruff-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4809df77de390a1c2077d9b7945d82f44b95d19ceccf0c287c56e4dc9b91ca64", size = 10557138 },
+    { url = "https://files.pythonhosted.org/packages/5e/5e/f62a1b6669870a591ed7db771c332fabb30f83c967f376b05e7c91bccd14/ruff-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f3a0c2e169e6b545f8e2dba185eabbd9db4f08880032e75aa0e285a6d3f48201", size = 10095726 },
+    { url = "https://files.pythonhosted.org/packages/45/59/a7aa8e716f4cbe07c3500a391e58c52caf665bb242bf8be42c62adef649c/ruff-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49b888200a320dd96a68e86736cf531d6afba03e4f6cf098401406a257fcf3d6", size = 11672265 },
+    { url = "https://files.pythonhosted.org/packages/dd/e3/101a8b707481f37aca5f0fcc3e42932fa38b51add87bfbd8e41ab14adb24/ruff-0.11.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2b19cdb9cf7dae00d5ee2e7c013540cdc3b31c4f281f1dacb5a799d610e90db4", size = 12331418 },
+    { url = "https://files.pythonhosted.org/packages/dd/71/037f76cbe712f5cbc7b852e4916cd3cf32301a30351818d32ab71580d1c0/ruff-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64e0ee994c9e326b43539d133a36a455dbaab477bc84fe7bfbd528abe2f05c1e", size = 11794506 },
+    { url = "https://files.pythonhosted.org/packages/ca/de/e450b6bab1fc60ef263ef8fcda077fb4977601184877dce1c59109356084/ruff-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bad82052311479a5865f52c76ecee5d468a58ba44fb23ee15079f17dd4c8fd63", size = 13939084 },
+    { url = "https://files.pythonhosted.org/packages/0e/2c/1e364cc92970075d7d04c69c928430b23e43a433f044474f57e425cbed37/ruff-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7940665e74e7b65d427b82bffc1e46710ec7f30d58b4b2d5016e3f0321436502", size = 11450441 },
+    { url = "https://files.pythonhosted.org/packages/9d/7d/1b048eb460517ff9accd78bca0fa6ae61df2b276010538e586f834f5e402/ruff-0.11.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:169027e31c52c0e36c44ae9a9c7db35e505fee0b39f8d9fca7274a6305295a92", size = 10441060 },
+    { url = "https://files.pythonhosted.org/packages/3a/57/8dc6ccfd8380e5ca3d13ff7591e8ba46a3b330323515a4996b991b10bd5d/ruff-0.11.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:305b93f9798aee582e91e34437810439acb28b5fc1fee6b8205c78c806845a94", size = 10058689 },
+    { url = "https://files.pythonhosted.org/packages/23/bf/20487561ed72654147817885559ba2aa705272d8b5dee7654d3ef2dbf912/ruff-0.11.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a681db041ef55550c371f9cd52a3cf17a0da4c75d6bd691092dfc38170ebc4b6", size = 11073703 },
+    { url = "https://files.pythonhosted.org/packages/9d/27/04f2db95f4ef73dccedd0c21daf9991cc3b7f29901a4362057b132075aa4/ruff-0.11.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:07f1496ad00a4a139f4de220b0c97da6d4c85e0e4aa9b2624167b7d4d44fd6b6", size = 11532822 },
+    { url = "https://files.pythonhosted.org/packages/e1/72/43b123e4db52144c8add336581de52185097545981ff6e9e58a21861c250/ruff-0.11.7-py3-none-win32.whl", hash = "sha256:f25dfb853ad217e6e5f1924ae8a5b3f6709051a13e9dad18690de6c8ff299e26", size = 10362436 },
+    { url = "https://files.pythonhosted.org/packages/c5/a0/3e58cd76fdee53d5c8ce7a56d84540833f924ccdf2c7d657cb009e604d82/ruff-0.11.7-py3-none-win_amd64.whl", hash = "sha256:0a931d85959ceb77e92aea4bbedfded0a31534ce191252721128f77e5ae1f98a", size = 11566676 },
+    { url = "https://files.pythonhosted.org/packages/68/ca/69d7c7752bce162d1516e5592b1cc6b6668e9328c0d270609ddbeeadd7cf/ruff-0.11.7-py3-none-win_arm64.whl", hash = "sha256:778c1e5d6f9e91034142dfd06110534ca13220bfaad5c3735f6cb844654f6177", size = 10677936 },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes configuration so the otel-collector service is running and the web application is configured correctly to send opentelemetry trace and metrics data to it.

This gets ruff linting working.

This moves all the opentelemetry related code into `app/observability.py` so it's all in one place.

This adds a basic test for the `/` endpoint asserting things about the response payload. Tests work by running with `RUNNING_UNITTESTS=1` in the environment which causes the observability setup to skip setting up opentelemetry exporters and providers. This is the recommended way to test applications that use opentelemetry libraries.

This adds environment configuration documentation to the `README.md`.