### PR TITLE
Fix compose develop config for otel collector

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -32,4 +32,5 @@ services:
     develop:
       watch:
         - path: ./collector-config.yaml
-          action: restart
+          target: /etc/otelcol-config.yaml
+          action: sync+restart


### PR DESCRIPTION
```
> docker compose version
Docker Compose version v2.30.3-desktop.1
```

I cloned the repo, ran `make run`, and encountered:

```
> make run
docker compose up
validating /Users/gbeckley/code/github/mozilla/mzcld-demo/compose.yaml: services.otel-collector.develop.watch.0.action services.otel-collector.develop.watch.0.action must be one of the following: "rebuild", "sync", "sync+restart"
make: *** [run] Error 15
```

I changed `restart` to `sync+restart` and tried `make run` again, and I encountered this:

```
> make run
docker compose up
services.otel-collector.develop.watch: target is required for non-rebuild actions: invalid compose project
make: *** [run] Error 15
```

so I added the same target as was in the volume.