### PR TITLE
Add CODEOWNERS (#7)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mozilla/cloud-engineering-wg

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mozilla/cloud-engineering-wg
+* @mozilla/mzcld-demo-wg


### PR DESCRIPTION
Setting this to cloud-engineering-wg since that matches the ownership set in webservices-infra.

Fixes #7.