### PR TITLE
Overhaul build-and-push workflow (#6)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      deployments: write
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This overhauls the build-and-push workflow to match the "Publishing Container images to GAR" example which uses the mozilla-it/docker-push action.

This adds a step that runs the tests in the Docker image.

This sets us up for tagging images for prod deployment.

This changes the nonprod image tag to be the short version of the sha rather than "latest".

After this change, this is the behavior:

1. **Pull requests** will trigger build-and-push, generate a version.json file, build a Docker image, and run the tests in the Docker image.

   Pull requests will not cause anything to be pushed to GAR.
2. **Merging a pull request** will trigger build-and-push, generate a version.json file, build a Docker image, run the tests, set IMAGE_TAG to a short version of the sha, and push the image to GAR.

   This will also push mzcld-demo-load-tests image to GAR with tag "latest".
3. **Tagging the main branch with a vYYYY.MM.DD tag** will trigger build-and-push, generate a version.json file, build a Docker image, run the tests, set IMAGE_TAG to the tag, and push the image to GAR.

   This will also push mzcld-demo-load-tests image to GAR with tag "latest".

Fixes #6 