### PR TITLE
Fix the image_repo_path value (#17)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -15,7 +15,7 @@ env:
   IMAGE_NAME: mzcld-demo
   LOAD_TESTS_IMAGE_NAME: mzcld-demo-load-tests
   GCP_PROJECT_ID: moz-fx-mzcld-demo-prod
-  IMAGE_NAMESPACE: us-docker.pkg.dev/moz-fx-mzcld-demo-prod/mzcld-demo-prod
+  IMAGE_REPO_PATH: moz-fx-mzcld-demo-prod/mzcld-demo-prod
 
 jobs:
   build-and-push:
@@ -51,7 +51,7 @@ jobs:
         uses: mozilla-it/deploy-actions/docker-push@v3.11.1
         with:
           local_image: ${{ env.IMAGE_NAME }}
-          image_repo_path: ${{ secrets.DOCKER_IMAGE_PATH }}
+          image_repo_path: ${{ env.IMAGE_REPO_PATH }}
           image_tag: ${{ env.IMAGE_TAG }}
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ env.GCP_PROJECT_ID }}


### PR DESCRIPTION
This sets the `image_repo_path` to a non-empty value. Pretty sure this should fix pushing the image and I'm pretty sure this is the right value.

Fixes #17