### PR TITLE
Fix target image path (#17)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -15,7 +15,7 @@ env:
   IMAGE_NAME: mzcld-demo-web
   LOAD_TESTS_IMAGE_NAME: mzcld-demo-load-tests
   GCP_PROJECT_ID: moz-fx-mzcld-demo-prod
-  IMAGE_REPO_PATH: moz-fx-mzcld-demo-prod/mzcld-demo-prod
+  IMAGE_REPO_PATH: moz-fx-mzcld-demo-prod/mzcld-demo-prod/mzcld-demo
 
 jobs:
   build-and-push:


### PR DESCRIPTION
The `image_repo_path` value should be the full path including the target file name. This adds the target file name part.